### PR TITLE
:muscle: Use `interface` instead for better docs

### DIFF
--- a/denops.ts
+++ b/denops.ts
@@ -13,7 +13,7 @@ export type Context = Record<string, unknown>;
 /**
  * Environment meta information.
  */
-export type Meta = {
+export interface Meta {
   // Current denops mode.
   // In "debug" or "test" mode, some features become enabled,
   // which might impact performance.
@@ -24,7 +24,7 @@ export type Meta = {
   readonly version: string;
   // Host platform name.
   readonly platform: "windows" | "mac" | "linux";
-};
+}
 
 /**
  * Batch error raised when one of the functions fails during batch process.
@@ -48,7 +48,7 @@ export class BatchError extends Error {
 /**
  * Denops is a facade instance visible from each denops plugin.
  */
-export type Denops = {
+export interface Denops {
   /**
    * Denops instance name used to communicate with Vim.
    */
@@ -127,4 +127,4 @@ export type Denops = {
    * @param args: Arguments of the function.
    */
   dispatch(name: string, fn: string, ...args: unknown[]): Promise<unknown>;
-};
+}


### PR DESCRIPTION
We'd like to use `type` to avoid unwilling declaration merging but deno_doc does not support jsdocs in `type` yet. That's why we use `interface` instead to show better docs.

https://github.com/denoland/deno_doc/issues/302

### Before

```
Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/mod.ts:1:1

  This module is a fundamental component of [denops.vim], an ecosystem for crafting plugins in [Deno] for Vim/Neovim.
  
  It's essential to highlight that the recommended practice for most users is to utilize the [denops_std] module when developing plugins for [denops.vim].
  The current module is structured as a foundational layer within [denops_std], and utilizing it directly from plugins is **strongly discouraged**.
  
  [deno]: https://deno.land/
  [denops.vim]: https://github.com/vim-denops/denops.vim
  [denops_std]: https://deno.land/x/denops_std

  @module

Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/denops.ts:32:1

class BatchError extends Error
  Batch error raised when one of the functions fails during batch process.

  constructor(message: string, results: unknown[])
  readonly results: unknown[]

Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/denops.ts:11:1

type Context = Record<string, unknown>
  Context that expands into the local namespace (l:)

Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/denops.ts:51:1

type Denops = { redraw(force?: boolean): Promise<void>; call(fn: string, ...args: unknown[]): Promise<unknown>; batch(...calls: [string, ...unknown[]][]): Promise<unknown[]>; cmd(cmd: string, ctx?: Context): Promise<void>; eval(expr: string, ctx?: Context): Promise<unknown>; dispatch(name: string, fn: string, ...args: unknown[]): Promise<unknown>; name: string; meta: Meta; context: Record<PropertyKey, unknown>; dispatcher: Dispatcher; }
  Denops is a facade instance visible from each denops plugin.

Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/denops.ts:4:1

type Dispatcher = { [key: string]: (...args: unknown[]) => unknown; }
  API dispatcher

Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/denops.ts:16:1

type Meta = { mode: "release" | "debug" | "test"; host: "vim" | "nvim"; version: string; platform: "windows" | "mac" | "linux"; }
  Environment meta information.

```

### After

```
Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/mod.ts:1:1

  This module is a fundamental component of [denops.vim], an ecosystem for crafting plugins in [Deno] for Vim/Neovim.
  
  It's essential to highlight that the recommended practice for most users is to utilize the [denops_std] module when developing plugins for [denops.vim].
  The current module is structured as a foundational layer within [denops_std], and utilizing it directly from plugins is **strongly discouraged**.
  
  [deno]: https://deno.land/
  [denops.vim]: https://github.com/vim-denops/denops.vim
  [denops_std]: https://deno.land/x/denops_std

  @module

Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/denops.ts:32:1

class BatchError extends Error
  Batch error raised when one of the functions fails during batch process.

  constructor(message: string, results: unknown[])
  readonly results: unknown[]

Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/denops.ts:51:1

interface Denops
  Denops is a facade instance visible from each denops plugin.

  readonly name: string
    Denops instance name used to communicate with Vim.
  readonly meta: Meta
    Environment meta information.
  readonly context: Record<PropertyKey, unknown>
    Context object for plugins.
  dispatcher: Dispatcher
    User-defined API name and method map used to dispatch API requests.
  redraw(force?: boolean): Promise<void>
    Redraw text and cursor on Vim.
    
    It is not equivalent to the `redraw` command in Vim script and does nothing on Neovim.
    Use `denops.cmd('redraw')` instead if you need to execute the `redraw` command.

    @param force:
        Clear the screen prior to redraw.

  call(fn: string, ...args: unknown[]): Promise<unknown>
    Call an arbitrary function of Vim/Neovim and return the result.

    @param fn:
        A function name of Vim/Neovim.

    @param args:
        Arguments of the function.
        
        Note that arguments after `undefined` in `args` will be dropped for convenience.

  batch(...calls: [string, ...unknown[]][]): Promise<unknown[]>
    Call arbitrary functions of Vim/Neovim sequentially without redraw and
    return the results.
    
    It throws a BatchError when one of the functions fails. The `results` attribute
    of the error instance holds succeeded results of functions prior to the
    error.

    @param calls:
        A list of tuples ([fn, args]) to call Vim/Neovim functions.
        
        Note that arguments after `undefined` in `args` will be dropped for convenience.

  cmd(cmd: string, ctx?: Context): Promise<void>
    Execute an arbitrary command of Vim/Neovim under a given context.

    @param cmd:
        A command expression to be executed.

    @param ctx:
        A context object that expands into the local namespace (l:)

  eval(expr: string, ctx?: Context): Promise<unknown>
    Evaluate an arbitrary expression of Vim/Neovim under a given context and return the result.

    @param expr:
        An expression to be evaluated.

    @param ctx:
        A context object that expands into the local namespace (l:)

  dispatch(name: string, fn: string, ...args: unknown[]): Promise<unknown>
    Dispatch an arbitrary function of an arbitrary plugin and return the result.

    @param name:
        A plugin registration name.

    @param fn:
        A function name in the API registration.

    @param args:
        Arguments of the function.


Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/denops.ts:16:1

interface Meta
  Environment meta information.

  readonly mode: "release" | "debug" | "test"
  readonly host: "vim" | "nvim"
  readonly version: string
  readonly platform: "windows" | "mac" | "linux"

Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/denops.ts:11:1

type Context = Record<string, unknown>
  Context that expands into the local namespace (l:)

Defined in file:///Users/alisue/ghq/github.com/vim-denops/deno-denops-core/denops.ts:4:1

type Dispatcher = { [key: string]: (...args: unknown[]) => unknown; }
  API dispatcher
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the structure of key data types for improved code semantics and maintainability.
- **Style**
	- Implemented minor formatting improvements for better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->