### PR TITLE
:tada: For Denops v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         run: deno fmt --check
       - name: Type check
         run: deno task check
+      - name: Test doc
+        run: deno task test
 
   jsr-publish:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+deno.lock

--- a/README.md
+++ b/README.md
@@ -3,14 +3,29 @@
 [![JSR](https://jsr.io/badges/@denops/core)](https://jsr.io/@denops/core)
 [![test](https://github.com/vim-denops/deno-denops/workflows/test/badge.svg)](https://github.com/vim-denops/deno-denops/actions?query=workflow%3Atest)
 
-This module is a fundamental component of [denops.vim], an ecosystem for
-crafting plugins in [Deno] for Vim/Neovim.
+This is a core module of [denops.vim], an ecosystem for creating Vim/Neovim
+plugin in [Deno].
 
-It's essential to highlight that the recommended practice for most users is to
-utilize the [denops_std] module when developing plugins for [denops.vim]. The
-current module is structured as a foundational layer within [denops_std], and
-utilizing it directly from plugins is **strongly discouraged**.
+> [!WARNING]
+>
+> This module is mainly for internal use. It's **strongly discouraged** to
+> utilize this module directly from plugins. Use the [@denops/std] module
+> instead.
+
+```ts
+import type { Entrypoint } from "jsr:@denops/core";
+
+export const main: Entrypoint = (denops) => {
+  // ...
+};
+```
 
 [deno]: https://deno.land/
 [denops.vim]: https://github.com/vim-denops/denops.vim
-[denops_std]: https://deno.land/x/denops_std
+[@denops/std]: https://jsr.io/@denops/std
+
+# License
+
+The code follows the MIT license, as stated in [LICENSE](./LICENSE).
+Contributors need to agree that any modifications sent to this repository follow
+the license.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # 🪐 denops_core
 
 [![JSR](https://jsr.io/badges/@denops/core)](https://jsr.io/@denops/core)
-[![denoland](https://img.shields.io/github/v/release/vim-denops/deno-denops-core?logo=deno&label=denoland)](https://deno.land/x/denops_core)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/denops_core/mod.ts)
 [![test](https://github.com/vim-denops/deno-denops/workflows/test/badge.svg)](https://github.com/vim-denops/deno-denops/actions?query=workflow%3Atest)
 
 This module is a fundamental component of [denops.vim], an ecosystem for

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -11,6 +11,6 @@
     "update:commit": "deno task -q update --commit --pre-commit=fmt,lint"
   },
   "imports": {
-    "https://deno.land/x/denops_core@$MODULE_VERSION/": "./"
+    "jsr:@denops/core": "./mod.ts"
   }
 }

--- a/denops.ts
+++ b/denops.ts
@@ -150,7 +150,7 @@ export interface Denops {
  * Use this type to ensure the `main` function is properly implemented like:
  *
  * ```ts
- * import type { Entrypoint } from "https://deno.land/x/denops_core@$MODULE_VERSION/mod.ts";
+ * import type { Entrypoint } from "jsr:@denops/core";
  *
  * export const main: Entrypoint = (denops) => {
  *   // ...
@@ -161,7 +161,7 @@ export interface Denops {
  * asynchronously when the plugin is unloaded, like:
  *
  * ```ts
- * import type { Entrypoint } from "https://deno.land/x/denops_core@$MODULE_VERSION/mod.ts";
+ * import type { Entrypoint } from "jsr:@denops/core";
  *
  * export const main: Entrypoint = (denops) => {
  *   // ...

--- a/denops.ts
+++ b/denops.ts
@@ -75,6 +75,11 @@ export interface Denops {
   readonly context: Record<PropertyKey, unknown>;
 
   /**
+   * AbortSignal instance that is triggered when the user invoke `denops#interrupt()`
+   */
+  readonly interrupted: AbortSignal;
+
+  /**
    * User-defined API name and method map used to dispatch API requests.
    */
   dispatcher: Dispatcher;

--- a/denops.ts
+++ b/denops.ts
@@ -147,7 +147,7 @@ export interface Denops {
 /**
  * Denops's entrypoint definition.
  *
- * Use this type to ensure the `main` function is properly implemented like
+ * Use this type to ensure the `main` function is properly implemented like:
  *
  * ```ts
  * import type { Entrypoint } from "https://deno.land/x/denops_core@$MODULE_VERSION/mod.ts";
@@ -156,5 +156,23 @@ export interface Denops {
  *   // ...
  * }
  * ```
+ *
+ * If an `AsyncDisposable` object is returned, resources can be disposed of
+ * asynchronously when the plugin is unloaded, like:
+ *
+ * ```ts
+ * import type { Entrypoint } from "https://deno.land/x/denops_core@$MODULE_VERSION/mod.ts";
+ *
+ * export const main: Entrypoint = (denops) => {
+ *   // ...
+ *   return {
+ *     [Symbol.asyncDispose]: async () => {
+ *       // Dispose resources...
+ *     }
+ *   }
+ * }
+ * ```
  */
-export type Entrypoint = (denops: Denops) => void | Promise<void>;
+export type Entrypoint = (
+  denops: Denops,
+) => void | AsyncDisposable | Promise<void | AsyncDisposable>;

--- a/denops.ts
+++ b/denops.ts
@@ -77,7 +77,7 @@ export interface Denops {
   /**
    * AbortSignal instance that is triggered when the user invoke `denops#interrupt()`
    */
-  readonly interrupted: AbortSignal;
+  readonly interrupted?: AbortSignal;
 
   /**
    * User-defined API name and method map used to dispatch API requests.

--- a/mod.ts
+++ b/mod.ts
@@ -6,7 +6,7 @@
  *
  * [deno]: https://deno.land/
  * [denops.vim]: https://github.com/vim-denops/denops.vim
- * [denops_std]: https://deno.land/x/denops_std
+ * [denops_std]: https://github.com/vim-denops/deno-denops-std
  *
  * @module
  */

--- a/mod.ts
+++ b/mod.ts
@@ -1,12 +1,24 @@
 /**
- * This module is a fundamental component of [denops.vim], an ecosystem for crafting plugins in [Deno] for Vim/Neovim.
+ * This is a core module of [denops.vim], an ecosystem for creating Vim/Neovim
+ * plugin in [Deno].
  *
- * It's essential to highlight that the recommended practice for most users is to utilize the [denops_std] module when developing plugins for [denops.vim].
- * The current module is structured as a foundational layer within [denops_std], and utilizing it directly from plugins is **strongly discouraged**.
+ * > [!WARNING]
+ * >
+ * > This module is mainly for internal use. It's **strongly discouraged** to
+ * > utilize this module directly from plugins. Use the [@denops/std] module
+ * > instead.
+ *
+ * ```ts
+ * import type { Entrypoint } from "jsr:@denops/core";
+ *
+ * export const main: Entrypoint = (denops) => {
+ *     // ...
+ * };
+ * ```
  *
  * [deno]: https://deno.land/
  * [denops.vim]: https://github.com/vim-denops/denops.vim
- * [denops_std]: https://github.com/vim-denops/deno-denops-std
+ * [@denops/std]: https://jsr.io/@denops/std
  *
  * @module
  */


### PR DESCRIPTION
## Ref

- https://github.com/vim-denops/denops.vim/pull/344
- https://github.com/vim-denops/deno-denops-core/pull/8
- https://github.com/vim-denops/deno-denops-std/pull/246
- https://github.com/vim-denops/deno-denops-test/pull/25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added support for asynchronous resource disposal upon plugin unloading.
  - Introduced a new `interrupted` property in the Denops interface.

- **Documentation**
  - Updated README to recommend using `@denops/std` and added examples for using the Entrypoint type.

- **Chores**
  - Added new file `deno.lock` to the repository.
  - Updated import paths in configuration files and module links for better consistency.

- **CI/CD**
  - Integrated a new testing step for documentation in the GitHub workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->