### PR TITLE
:+1: run doc test on test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         run: deno fmt --check
       - name: Type check
         run: deno task check
+      - name: Test doc
+        run: deno task test
 
   jsr-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`deno check` does not check examples in jsdoc comments.