### PR TITLE
feat: Add Call type for Vim/Neovim function call representation

### DIFF
--- a/type.ts
+++ b/type.ts
@@ -20,6 +20,14 @@ export type Dispatcher = {
 };
 
 /**
+ * Represents a Vim/Neovim function call.
+ *
+ * `fn`: A function name of Vim/Neovim.
+ * `args`: Arguments of the function.
+ */
+export type Call = [fn: string, ...args: unknown[]];
+
+/**
  * Context that expands into the local namespace (l:)
  */
 export type Context = Record<string, unknown>;
@@ -138,11 +146,11 @@ export interface Denops {
    * of the error instance holds succeeded results of functions prior to the
    * error.
    *
-   * @param calls: A list of tuples ([fn, args]) to call Vim/Neovim functions.
+   * @param calls: A list of tuples ([fn, ...args]) to call Vim/Neovim functions.
    *
    * Note that arguments after `undefined` in `args` will be dropped for convenience.
    */
-  batch(...calls: [string, ...unknown[]][]): Promise<unknown[]>;
+  batch(...calls: Call[]): Promise<unknown[]>;
 
   /**
    * Execute an arbitrary command of Vim/Neovim under a given context.


### PR DESCRIPTION
## Summary

This PR introduces a new `Call` type to represent Vim/Neovim function call tuples, improving type reusability and code
maintainability.

## Motivation

Currently, every method that uses function call tuples needs to redefine the tuple type `[string, ...unknown[]]` inline. This
approach violates the DRY (Don't Repeat Yourself) principle and leads to:

- **Type duplication**: The same tuple structure is redefined multiple times across the codebase
- **Inconsistency risks**: Different implementations might define slightly different tuple types
- **Reduced maintainability**: Changes to the tuple structure would require updates in multiple locations

In practice, we already see this issue in the ecosystem:
- `@denops/std/batch` and other modules redefine similar tuple types
- Each implementation creates its own version of essentially the same type

## Changes

- Added `Call` type definition
- Updated batch method signature to use the `Call` type
- Improved JSDoc comments for clarity
  - **Note**: JSDoc does not support `@param` tags for labeled tuple elements, so `fn` and `args` are documented as regular text descriptions

## Compatibility

This change is fully backward compatible:
- The `Call` type is simply an extraction of the existing tuple structure
- No runtime behavior changes
- No breaking changes to the API
- Existing code continues to work without modifications
- The type signature remains exactly the same

This aligns with the `@denops/core` philosophy of maintaining stability while improving developer experience.

## Future Plans

Once this change is merged, we plan to:
1. Re-export the `Call` type from `@denops/std` for plugin developers
  - Plugin developers will import from `@denops/std` (following the principle that `@denops/core` is not directly used by plugin
developers)
  - This will provide a single, canonical type for function calls across the ecosystem
2. Update existing modules in `@denops/std` to use this type, eliminating duplications

## Benefits

1. **Better DX**: Developers can import and reuse the `Call` type (via `@denops/std`)
2. **Type consistency**: Single source of truth for function call tuple type
3. **Improved maintainability**: Future changes to the call structure only need updates in one place
4. **Documentation**: The type itself serves as documentation for what a "call" represents
5. **Ecosystem alignment**: Provides a foundation for consistent type usage across denops libraries

## Testing

- Type-only change, no runtime impact
- Existing tests continue to pass
- TypeScript compiler validates the type compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined batch method API signature for improved consistency and type clarity in function invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->